### PR TITLE
398 issue: Tests must not rely on port 8080

### DIFF
--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/BasicAuthenticationTest.java
@@ -44,8 +44,8 @@ public class BasicAuthenticationTest {
 
   ProcessInstanceApi api;
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+ @Rule
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Before
   public void clientWithValidCredentials() {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/DeploymentTest.java
@@ -41,7 +41,7 @@ public class DeploymentTest {
   final DeploymentApi api = new DeploymentApi();
 
   @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Test
   public void shouldCreateDeployment() throws ApiException {

--- a/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
+++ b/engine-rest/engine-rest-openapi/src/test/java/org/operaton/bpm/engine/rest/openapi/client/ProcessInstanceTest.java
@@ -44,8 +44,8 @@ public class ProcessInstanceTest {
 
   final ProcessInstanceApi api = new ProcessInstanceApi();
 
-  @Rule
-  public WireMockRule wireMockRule = new WireMockRule(8080);
+ @Rule
+public WireMockRule wireMockRule = new WireMockRule(WireMockConfiguration.options().dynamicPort());
 
   @Test
   public void shouldQueryProcessInstancesCount() throws ApiException {


### PR DESCRIPTION
I have made changes to the port number for the test. Now the test will be allocated dynamic port